### PR TITLE
Increase all heading levels by one

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+    "MD041": false,
+    "default": false
+}

--- a/docs/about/1-om-trafikkdata.md
+++ b/docs/about/1-om-trafikkdata.md
@@ -8,8 +8,7 @@ Trafikkregistreringsstasjoner har ett eller flere trafikkregistreringspunkter kn
 
 Trafikkregistreringsstasjoner består av fysisk infrastruktur ved vegen, som skap o.l. Informasjon om disse kan være relevant for de som drifter og vedlikeholder veg og tilknyttet infrastruktur, og er tilgjengelig i NVDB, se for eksempel [vegkart.no](http://vegkart.no).
 
-
-## Motorkjøretøy
+### Motorkjøretøy
 
 Trafikken registreres ved hjelp av induktive sløyfer i vegbanen. Når en bil kjører over sløyfene registreres lengde, fart, kjøretøyklasse og avstand i sekunder til forangående kjøretøy. Det registreres også hvilket kjørefelt og kjøreretning bilen kjører i. Kjørefeltet angis alltid som den faktiske, fysiske plasseringen av bilen i vegbanen. Kjøreretningen angis som den faktiske kjøreretningen til bilen. I tilfeller der bilen kjører på "feil" side av vegen, blir kjøreretningen angitt som den motsatte av feltets angitte retning. Dette vil forekomme ved forbikjøringer. Dersom bilen passerer midt mellom de induktive sløyfene i to motgående kjørefelt, kan bilen få angitt motsatt kjørefelt, men likevel riktig, faktisk kjøreretning.
 
@@ -23,28 +22,25 @@ Alle registrerte kjøretøy blir klassifisert etter kjøretøytype, og motorsykk
 
 ![Figuren viser hvordan trafikken blir registrert og overført til trafikkdatasystemet i sanntid.](images/data-collection.png)
 
-
-## Sykkel
+### Sykkel
 
 Sykkeltrafikk kan registreres med ulike sensorer. I dag benyttes induktive sløyfer og piezoelektriske kabler som legges i gang/sykkelvegene. Når en syklist passerer sensoren registreres farten. Registreringene overføres på samme måte som for motorkjøretøy.
 
 ![Sløyfer og måleskap på St. Olavs Pir ved Skansen i Trondheim.](images/loop-and-datalogger.png)
 
+### Registreringshyppighet
 
-## Registreringshyppighet
 Med registreringshyppighet menes hvor ofte trafikken registreres ved et trafikkregistreringspunkt. Hyppigheten kan være en av to verdier: kontinuerlig eller periodisk.
 
 Kontinuerlige registreringer foretas døgnet rundt, hele året, år etter år.
 
 Periodiske registreringer foretas døgnet rundt i kortere perioder, typisk i en ukes tid. Registreringsperioden gjentas så 4-5 ganger samme kalenderår. Prosedyren gjentas så hvert fjerde år.
 
+### Overgang fra “ukjent” til “kjent datakvalitet”
 
-## Overgang fra “ukjent” til “kjent datakvalitet”
+I perioden 2015 - 2018 ble det gradvis gått over til ny løsning for innsamling og kvalitetskontroll av data. Tidspunktet for denne endringen er ulikt for hvert trafikkregistreringspunkt, men sammenfaller med overgangen fra “ukjent” til “kjent” datakvalitet som er angitt i datovelgeren på hvert punkt. Med “kjent” kvalitet menes at hver kjøretøyregistrering er blitt vurdert opp mot kvalitetskriterier og at alle aggregerte og beregnede størrelser kommer med kvalitetsinformasjon i form av dekningsgrad.
 
-I perioden 2015 - 2018 ble det gradvis gått over til ny løsning for innsamling og kvalitetskontroll av data.  Tidspunktet for denne endringen er ulikt for hvert trafikkregistreringspunkt, men sammenfaller med overgangen fra “ukjent” til “kjent” datakvalitet som er angitt i datovelgeren på hvert punkt. Med “kjent” kvalitet menes at hver kjøretøyregistrering er blitt vurdert opp mot kvalitetskriterier og at alle aggregerte og beregnede størrelser kommer med kvalitetsinformasjon i form av dekningsgrad.
-
-
-## Stedfesting på vegnettet
+### Stedfesting på vegnettet
 
 Alle trafikkregistreringspunkter er stedfestet på vegnettet med en vegsystemreferanse. Vegsystemreferansen angir blant annet vegens vegkategori, vegnummer og strekningsnummer. En del av vegsystemreferansen er en meterverdi som kommer fra oppmåling av vegen i sin lengderetning. Denne oppmålingen omtales som "metrering". Vegene måles opp på vegtrasenivå og har dermed samme meterverdi for alle kjørefelt, unntatt når vegen har adskilte løp som metreres for seg. Vegene metreres ut fra et geografisk punkt, som varierer fra veg til veg.
 
@@ -52,8 +48,7 @@ Trafikken registreres i hvert kjørefelt, som benevnes med et kjørefeltnummer. 
 
 For mer detaljer om vegsystemreferansen, se Statens vegvesens Håndbok V830 Nasjonalt vegreferansesystem, som er tilgjengelig på [vegvesen.no](https://www.vegvesen.no/fag/publikasjoner/handboker).
 
-
-### Kjørefeltnummer ved snudd metreringsretning
+#### Kjørefeltnummer ved snudd metreringsretning
 
 Vegsystemreferansen endrer seg når selve vegnettet endrer seg, som ved bygging av ny veg. Retningen som vegen er oppmålt i kan snus, og dette har skjedd i en del tilfeller i forbindelse med innføring av nytt vegreferansesystem i 2019. Endret metreringsretning medfører at kjørefeltnummer også endrer seg. I Trafikkdataportalen vises alltid kjørefeltnummer i henhold til nåværende metrering, også for historiske data. Kjørefeltenes beskrivelser med stedsnavn vil alltid være korrekt og uendret for det fysiske kjørefeltet, selv om nummeret har endret seg.
 

--- a/docs/about/2-datakvalitet.md
+++ b/docs/about/2-datakvalitet.md
@@ -1,8 +1,8 @@
-# Datakvalitet
+## Datakvalitet
 
 Alle kjøretøyregistreringer blir kontrollert mot et sett med kvalitetsregler, som er utarbeidet i samråd med utstyrsleverandørene og basert på Statens vegvesens egne tester av registreringsutstyret.
 
-## Kvalitetsregler
+### Kvalitetsregler
 
 Kvalitetsreglene er i korthet skissert her.
 
@@ -27,7 +27,7 @@ I tillegg kommer noen apparatspesifikke regler som baseres på leverandørenes e
 
 For sykkelregistreringer har vi ikke flere regler enn at selve registreringen er ugyldig dersom utstyret mener det var noe annet enn en sykkel som ble registrert.
 
-## Kvalitetsmerker
+### Kvalitetsmerker
 
 Resultatet av kontrollen er at enkeltkjøretøydata lagres med følgende kvalitetsmerker i databasen:
 
@@ -50,15 +50,15 @@ Basert på dette kan vi angi andelen godkjente registreringer i et tidsintervall
 
 - `klassifiseringskvalitetsgrad = (antall registreringer med gyldig klassifisering i perioden) / (totalt antall gyldige registreringer i perioden) * 100 %`
 
-## Bortfall av data
+### Bortfall av data
 
 Det kan være ulike grunner til at data ikke blir registrert eller får systematisk lavere kvalitet i perioder.
 
-### Operasjonell status på målestasjon
+#### Operasjonell status på målestasjon
 
 Registreringsutstyret er operasjonelt fra det tidspunktet det blir igangsatt til det blir satt ut av drift. Dette er manuelle handlinger. Perioder utenfor det operasjonelle intervallet skal ikke være tellende med nulltrafikk i beregninger. Derfor har trafikkdatasystemet lagret informasjon om alle tidspunkt for igangsetting og ut-av-driftssettelse.
 
-### Fulltallighet
+#### Fulltallighet
 
 Fulltallighet er et mål på andelen overførte data fra registreringsapparatet.
 Fulltallighet er definert slik:
@@ -67,7 +67,7 @@ Fulltallighet er definert slik:
 
 Fulltalligheten gjelder for hele timer, og gjelder samlet for en målestasjons registreringsapparat. Fulltalligheten er per definisjon 100 % i timer helt uten trafikk, unntatt i tilfeller hvor det mangler overføring av data over flere timer.
 
-### Manuell merking
+#### Manuell merking
 
 Manuell merking brukes av de målestasjonsansvarlige til å legge inn informasjon om hendelser på vegen eller med registreringsutstyret som påvirker trafikkregistreringene. Perioder kan merkes per kjørefelt med:
 
@@ -78,7 +78,7 @@ Manuell merking brukes av de målestasjonsansvarlige til å legge inn informasjo
 
 Senere vil de manuelle merkingene bli tilgjengeliggjort sammen med data de gjelder for i trafikkdataportalen og API-et.
 
-### Dekningsgrad
+#### Dekningsgrad
 
 Dekningsgrad angir hvor mye data (antall timer og dager) av god nok kvalitet vi har, sammenlignet med det vi hadde hatt uten bortfall.
 For aggregerte data (timetrafikk og døgntrafikk) vil en dekningsgrad på 50% bety at vi bare har data fra 50% av perioden og at den reelle trafikkmengden derfor er større.

--- a/docs/about/3-beregningsmetodikk.md
+++ b/docs/about/3-beregningsmetodikk.md
@@ -1,19 +1,16 @@
-# Beregningsmetodikk
+## Beregningsmetodikk
 
 Grunnlaget for aggregerte og beregnede trafikkmengdestørrelser er kontrollerte kjøretøyregistreringer.
 
-
-## Timetrafikk
+### Timetrafikk
 
 Timetrafikk er antall godkjente kjøretøyregistreringer i den aktuelle klokketimen. Trafikkmengden oppgis uansett dekningsgrad for timen.
 
-
-## Døgntrafikk
+### Døgntrafikk
 
 Døgntrafikk er antall godkjente kjøretøyregistreringer i det aktuelle døgnet, og er summen av timetrafikken i det samme døgnet. Trafikkmengden oppgis uansett dekningsgrad for døgnet.
 
-
-## Gjennomsnittlig døgntrafikk
+### Gjennomsnittlig døgntrafikk
 
 Gjennomsnittlig døgntrafikk beregnes per måned, sesong og år. Her inngår kun døgntrafikk som har minst 95 % dekningsgrad. For den aktuelle perioden er den gjennomsnittlige døgntrafikken beregnet som det aritmetiske gjennomsnittet. I tillegg beregnes standardavvik og konfidensintervall.
 

--- a/docs/about/4-om-fartsdata.md
+++ b/docs/about/4-om-fartsdata.md
@@ -1,4 +1,4 @@
-# Om fartsdata
+## Om fartsdata
 
 Fartsdata er data om fartsnivået på vegnettet som registreres og samles opp av målepunkter langs veiene. Trafikkdata.no har punktmålinger fra trafikkregistreringsstasjoner på det statlige og fylkeskommunale vegnettet samt noen kommunale veger.
 
@@ -8,21 +8,24 @@ Trafikkregistreringspunktene registrerer fart, lengde på kjøretøyet og avstan
 
 Med de rette tilgangene kan man laste ned fartsdatarapporter.
 
-## Hvordan få tilgang til fartsdata
+### Hvordan få tilgang til fartsdata
+
 Under er en oversikt over hvordan du skal gå frem for å få tilgang til fartsdata.
 
-### For interne i Statens Vegvesen
+#### For interne i Statens Vegvesen
+
 For deg som er ansatt i Statens Vegvesen.
 
-* Logg inn på [selvbetjeningsportalen](https://www.vegvesen.no/idportalen/selvbetjening/) for tilganger og søk om enten “Trafikkdata – Fart – Alle veier” eller “Trafikkdata – Fart – Riksveier” etter tjenstlig behov
-* Logg inn og ta fartsdata i bruk
+- Logg inn på [selvbetjeningsportalen](https://www.vegvesen.no/idportalen/selvbetjening/) for tilganger og søk om enten “Trafikkdata – Fart – Alle veier” eller “Trafikkdata – Fart – Riksveier” etter tjenstlig behov
+- Logg inn og ta fartsdata i bruk
 
-### For andre vegeiere
+#### For andre vegeiere
+
 For deg som ikke er ansatt i Statens Vegvesen, men som trenger fartsdata.
 
-* Kontakt organisasjonen du trenger tilgang til fartsdata fra og be om Altinnrollen “Administrere trafikkdata”
-* Kontakt trafikkdata@vegvesen.no når du har fått rollen og be om tilgang til fartsdata
-* Svar på invitasjonen du får tilsendt på e-post
-* Logg inn og ta fartsdata i bruk
+- Kontakt organisasjonen du trenger tilgang til fartsdata fra og be om Altinnrollen “Administrere trafikkdata”
+- Kontakt trafikkdata@vegvesen.no når du har fått rollen og be om tilgang til fartsdata
+- Svar på invitasjonen du får tilsendt på e-post
+- Logg inn og ta fartsdata i bruk
 
 Dersom du har spørsmål eller andre behov for fartsdata, send en e-post til trafikkdata@vegvesen.no.

--- a/docs/about/5-om-eksportfilene.md
+++ b/docs/about/5-om-eksportfilene.md
@@ -1,4 +1,4 @@
-# Om eksportfilene
+## Om eksportfilene
 
 Data blir eksportert som en CSV-fil. CSV står for "Comma-separated values", et filformat som representerer data i tabellform. Første linje i filen definerer kolonnetitler, mens påfølgende linjer representerer rader. For å gjøre bruk i norske versjoner av Excel enklere er hver rad delt i kolonner med semikolon som separatortegn. For andre versjoner av Excel må en selv spesifisere semikolon som separatortegn.
 

--- a/docs/about/6-endringslogg.md
+++ b/docs/about/6-endringslogg.md
@@ -1,12 +1,12 @@
-# Endringslogg
+## Endringslogg
 
 Alle større endringer på Trafikkdata.no vil dokumenteres her.
 
-## 17.01.2023
+### 17.01.2023
 
 Vi har lagt til informasjon om eksport av fartsdata, dekningsgrad, samt supplementert med nye bregrepsdefinisjoner.
 
-## 12.12.2022
+### 12.12.2022
 
 **CSV-eksport.**
 
@@ -15,6 +15,6 @@ Tidligere ble både "Volum" og "Antall passeringer" brukt om trafikkmengde på n
 
 CSV-eksport: kolonne-overskriften "Volum" endres til "Trafikkmengde". Eventuelle klient-endringer må tilpasses deretter.
 
-## 24.02.2021
+### 24.02.2021
 
 Endringer på Trafikkdata.no vil publiseres her, i tillegg til å bli publisert på Twitter-kontoen [@VegvesenData](https://twitter.com/vegvesendata).

--- a/docs/about/7-om-dekningsgrad.md
+++ b/docs/about/7-om-dekningsgrad.md
@@ -1,71 +1,83 @@
-# Om dekningsgrad
-## Generell informasjon 
+## Om dekningsgrad
+
+### Generell informasjon
+
 Et trafikkregistreringspunkt har ikke alltid klart å fange opp all trafikk med gode måleverdier. Måleusikkerhet er noe en bruker av trafikkdata må være oppmerksom på. Derfor bør alle trafikkdataverdier ha tilknyttet informasjon om måleusikkerheten. Dekningsgrad sier noe om måleusikkerheten ved å angi hvor stor andel av et tidsintervall en trafikkregistrering har data for.
 
 I filene som kan eksporteres fra trafikkdataportalen finnes det tre ulike dekningsgrader: dekningsgrad for trafikkmengde, dekningsgrad for fart, og dekningsgrad for fart med lengdeklasser.
 
-## Manuelle merkinger
-Manuelle merkinger er lagt inn av fagpersoner som har vurdert datakvaliteten på den aktuelle trafikkregistreringen. En merking gjelder for et angitt tidsintervall og kan enten synliggjøre bortfall av data eller være til opplysning om unormale trafikkforhold.  
-  
-Manuelle merkinger kan gjelde ett eller flere av følgende forhold:  
-* Stengt veg  
-* Feil på utstyr (ingen gyldige data)  
-* Feil lengdemålinger  
-* Feil fartsmålinger  
-* Feil kjøretøyklassifisering  
-* Unormal trafikkmengde  
-* Unormalt fartsnivå
+### Manuelle merkinger
 
-## Matematisk formulering
-Dekningsgraden er satt sammen av flere komponenter som hver enkelt kan beskrives som en funksjon av en parameter.  
-  
-Operasjonelltid kan modelleres som en enhetsstegfunksjon som er lik 1 når trafikkregistreringspunktet er operasjonelt og 0 ellers.  
-  
-Dataoverføringskomplettheten (også kalt fulltallighet) kan modelleres som en kontinuerlig funksjon med verdimengde mellom 0 og 1, der 1 angir at alle data er overført og 0 angir at ingen data er overført.  
-  
-Manuelle merkinger for stengt veg og for feil i registrering kan hver for seg modelleres som enhetsstegfunksjoner som er lik 1 når registreringen ikke har feil ved seg, og lik 0 dersom en manuell merking er lagt inn for det aktuelle tidsintervallet.  
-  
-Andel gyldige verdier for lengde, fart og kjøretøyklasse kan hver enkelt modelleres som en kontinuerlig funksjon med verdimengde mellom 0 og 1, der 1 angir at alle data har gyldig verdi for respektive målestørrelse.  
-  
+Manuelle merkinger er lagt inn av fagpersoner som har vurdert datakvaliteten på den aktuelle trafikkregistreringen. En merking gjelder for et angitt tidsintervall og kan enten synliggjøre bortfall av data eller være til opplysning om unormale trafikkforhold.
+
+Manuelle merkinger kan gjelde ett eller flere av følgende forhold:
+
+- Stengt veg
+- Feil på utstyr (ingen gyldige data)
+- Feil lengdemålinger
+- Feil fartsmålinger
+- Feil kjøretøyklassifisering
+- Unormal trafikkmengde
+- Unormalt fartsnivå
+
+### Matematisk formulering
+
+Dekningsgraden er satt sammen av flere komponenter som hver enkelt kan beskrives som en funksjon av en parameter.
+
+Operasjonelltid kan modelleres som en enhetsstegfunksjon som er lik 1 når trafikkregistreringspunktet er operasjonelt og 0 ellers.
+
+Dataoverføringskomplettheten (også kalt fulltallighet) kan modelleres som en kontinuerlig funksjon med verdimengde mellom 0 og 1, der 1 angir at alle data er overført og 0 angir at ingen data er overført.
+
+Manuelle merkinger for stengt veg og for feil i registrering kan hver for seg modelleres som enhetsstegfunksjoner som er lik 1 når registreringen ikke har feil ved seg, og lik 0 dersom en manuell merking er lagt inn for det aktuelle tidsintervallet.
+
+Andel gyldige verdier for lengde, fart og kjøretøyklasse kan hver enkelt modelleres som en kontinuerlig funksjon med verdimengde mellom 0 og 1, der 1 angir at alle data har gyldig verdi for respektive målestørrelse.
+
 Dekningsgraden kan dermed enkelt regnes ut som produktet av de relevante funksjonene. Utregningsmetoden for de ulike dekningsgradene er beskrevet i det følgende.
 
-## Dekningsgrad for trafikkmengde
-Dekningsgrad for trafikkmengde settes sammen av følgende verdier som vist i figur 1:  
-* Operasjonelltid  
-* Dataoverføringskompletthet (fulltallighet)  
-* Manuell merking for stengt veg  
-* Manuell merking for feil på utstyr (ingen gyldige data)
+### Dekningsgrad for trafikkmengde
+
+Dekningsgrad for trafikkmengde settes sammen av følgende verdier som vist i figur 1:
+
+- Operasjonelltid
+- Dataoverføringskompletthet (fulltallighet)
+- Manuell merking for stengt veg
+- Manuell merking for feil på utstyr (ingen gyldige data)
 
 ![Figur 1. Beregning av dekningsgrad for trafikkmengde](images/dekningsgrad-for-trafikkmengde.svg)
 
-## Dekningsgrad for fart
-Dersom et målepunkt har mulighet til å måle fart, men ikke lengde på kjøretøyene, vil en dekningsgrad som kun tar hensyn til fart brukes.  
-  
-Dekningsgrad for fart settes sammen av følgende verdier som vist i figur 2:  
-* Operasjonelltid  
-* Dataoverføringskompletthet (fulltallighet)  
-* Antall gyldige fartsmålinger delt på totalt antall fartsmålinger
-* Manuell merking for stengt veg  
-* Manuell merking for feil på utstyr (ingen gyldige data)  
-* Manuell merking for feil fartsmålinger
+### Dekningsgrad for fart
+
+Dersom et målepunkt har mulighet til å måle fart, men ikke lengde på kjøretøyene, vil en dekningsgrad som kun tar hensyn til fart brukes.
+
+Dekningsgrad for fart settes sammen av følgende verdier som vist i figur 2:
+
+- Operasjonelltid
+- Dataoverføringskompletthet (fulltallighet)
+- Antall gyldige fartsmålinger delt på totalt antall fartsmålinger
+- Manuell merking for stengt veg
+- Manuell merking for feil på utstyr (ingen gyldige data)
+- Manuell merking for feil fartsmålinger
 
 ![Figur 2. Beregning av dekningsgrad for fartsmålinger](images/dekningsgrad-for-fart.svg)
 
-## Dekningsgrad for fart med lengdeklasser
-Måling av fart og lengde er gjerne sterkt korrelert på grunn av måten de regnes ut av registreringsutstyret på. Et aggregat av trafikkdata må derfor ha knyttet til seg en andel av registreringene som har både gyldig lengdemåling og fartsmåling.  
-  
-Dekningsgrad for fart med lengdeklasser settes sammen av følgende verdier som vist i figur 3:  
-* Operasjonelltid  
-* Dataoverføringskompletthet (fulltallighet)  
-* Antall målinger med både gyldig lengde og fart delt på totalt antall målinger
-* Manuell merking for stengt veg  
-* Manuell merking for feil på utstyr (ingen gyldige data)  
-* Manuell merking for feil lengdemålinger  
-* Manuell merking for feil fartsmålinger
+### Dekningsgrad for fart med lengdeklasser
+
+Måling av fart og lengde er gjerne sterkt korrelert på grunn av måten de regnes ut av registreringsutstyret på. Et aggregat av trafikkdata må derfor ha knyttet til seg en andel av registreringene som har både gyldig lengdemåling og fartsmåling.
+
+Dekningsgrad for fart med lengdeklasser settes sammen av følgende verdier som vist i figur 3:
+
+- Operasjonelltid
+- Dataoverføringskompletthet (fulltallighet)
+- Antall målinger med både gyldig lengde og fart delt på totalt antall målinger
+- Manuell merking for stengt veg
+- Manuell merking for feil på utstyr (ingen gyldige data)
+- Manuell merking for feil lengdemålinger
+- Manuell merking for feil fartsmålinger
 
 ![Figur 3. Beregning av dekningsgrad for fartsmålinger med lengdeklassifisering](images/dekningsgrad-for-fart-med-lengdeklasser.svg)
 
-## Samlet dekningsgrad for flere enn ett kjørefelt
-Trafikkdatastørrelser som er beregnet for flere enn ett kjørefelt får en tilsvarende dekningsgrad. Dersom alle kjørefelt har dekningsgrad forskjellig fra null er dekningsgraden for kjøreretningen lik det aritmetiske gjennomsnittet av kjørefeltenes dekningsgrad. Dersom minst ett kjørefelt har dekningsgrad lik null, så blir dekningsgraden for den kjøreretningen også null.  
-  
+### Samlet dekningsgrad for flere enn ett kjørefelt
+
+Trafikkdatastørrelser som er beregnet for flere enn ett kjørefelt får en tilsvarende dekningsgrad. Dersom alle kjørefelt har dekningsgrad forskjellig fra null er dekningsgraden for kjøreretningen lik det aritmetiske gjennomsnittet av kjørefeltenes dekningsgrad. Dersom minst ett kjørefelt har dekningsgrad lik null, så blir dekningsgraden for den kjøreretningen også null.
+
 Samme metodikk gjelder også for begge kjøreretningene samlet.

--- a/docs/about/8-tilgjengelighet.md
+++ b/docs/about/8-tilgjengelighet.md
@@ -1,3 +1,3 @@
-# Tilgjengelighet
+## Tilgjengelighet
 
 Denne nettsiden har blitt vurdert opp mot gjeldende WCAG-krav for universell utforming. Du kan finne [tilgjengelighetserklæringen (2023) her](https://uustatus.no/nb/erklaringer/publisert/52679a09-4af7-486f-87b5-49986439711a).

--- a/docs/api/2-usage.md
+++ b/docs/api/2-usage.md
@@ -1,4 +1,4 @@
-# Usage
+## Usage
 
 The Traffic Data API is located at [https://www.vegvesen.no/trafikkdata/api](https://www.vegvesen.no/trafikkdata/api).
 
@@ -14,7 +14,7 @@ For more information, visit [graphql.org/code](https://graphql.org/code/).
 In the following, we present a few examples of API queries.
 For full documentation of all available queries and fields, use the [GraphiQL interface](https://www.vegvesen.no/trafikkdata/api) and click on `Docs`.
 
-## Traffic registration points
+### Traffic registration points
 
 A traffic registration point is a location on the road where traffic is registered. For more information, see [Om trafikkdata](om-trafikkdata).
 The `trafficRegistrationPoints` query allows users to list traffic registration points that satisfy certain criteria.
@@ -40,11 +40,11 @@ The following example lists all traffic registration points on European routes, 
 
 [Open query in GraphiQL](<https://www.vegvesen.no/trafikkdata/api/?query=%7B%0A%20%20trafficRegistrationPoints(searchQuery%3A%20%7BroadCategoryIds%3A%20%5BE%5D%7D)%20%7B%0A%20%20%20%20id%0A%20%20%20%20name%0A%20%20%20%20location%20%7B%0A%20%20%20%20%20%20coordinates%20%7B%0A%20%20%20%20%20%20%20%20latLon%20%7B%0A%20%20%20%20%20%20%20%20%20%20lat%0A%20%20%20%20%20%20%20%20%20%20lon%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D>).
 
-## Traffic volume
+### Traffic volume
 
 Traffic volume for a given traffic registration point can be retrieved using the `trafficData` query.
 
-### Hourly traffic volume
+#### Hourly traffic volume
 
 The following example retrieves hourly traffic volume for two hours for the traffic registration point with ID `44656V72812`.
 
@@ -80,7 +80,7 @@ The following example retrieves hourly traffic volume for two hours for the traf
 The hourly and daily traffic volume (`byHour` and `byDay`) queries use pagination to split the data into pages, so that clients can process smaller chunks (maximum 100 hours/days) of data at a time.
 To retrieve the next page, use the `cursor` value from the last `node` on the current page as the `after` argument in the next query.
 
-### Average daily traffic volume per year (ÅDT)
+#### Average daily traffic volume per year (ÅDT)
 
 The following example retrieves average daily traffic volume per year for the traffic registration point with ID `44656V72812`.
 
@@ -114,7 +114,7 @@ The following example retrieves average daily traffic volume per year for the tr
 
 [Open query in GraphiQL](<https://www.vegvesen.no/trafikkdata/api/?query=%7B%0A%20%20trafficData(trafficRegistrationPointId%3A%20%2244656V72812%22)%20%7B%0A%20%20%20%20volume%20%7B%0A%20%20%20%20%20%20average%20%7B%0A%20%20%20%20%20%20%20%20daily%20%7B%0A%20%20%20%20%20%20%20%20%20%20byYear%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20year%0A%20%20%20%20%20%20%20%20%20%20%20%20total%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20volume%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20average%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20confidenceInterval%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20lowerBound%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20upperBound%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20coverage%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20percentage%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D>).
 
-### Traffic volume indices
+#### Traffic volume indices
 
 A traffic volume index is a measure of how much traffic has increased or decreased from one year to the next.
 The `trafficVolumeIndices` query returns indices for traffic registration points for a given month.
@@ -150,15 +150,15 @@ where `962` is the current ID of Vegtrafikkindeksen, which encompasses the whole
 
 [Open query in GraphiQL](<https://www.vegvesen.no/trafikkdata/api/?query=%7B%0A%09publishedAreaTrafficVolumeIndex(id%3A%20962%2C%20year%3A%202019%2C%20month%3A%2012)%20%7B%0A%20%20%20%20aggregatedTrafficVolumeIndex(areaTypes%3A%20%5BCOUNTRY%5D)%20%7B%0A%20%20%20%20%20%20byRoadCategoryCombination%20%7B%0A%20%20%20%20%20%20%20%20roadCategoryCombination%0A%20%20%20%20%20%20%20%20last12MonthsIndicesByDayType%20%7B%0A%20%20%20%20%20%20%20%20%20%20dayType%0A%20%20%20%20%20%20%20%20%20%20byLengthRange%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20lengthRange%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20representation%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20volumeIndexNumber%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20percentageChange%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A>)
 
-### Other queries
+#### Other queries
 
 The API can also provide traffic data for average daily traffic volume for months and seasons, as well as traffic volume per day.
 
-## Examples
+### Examples
 
 Usage examples from different languages that query the API for all traffic registration points on county roads.
 
-### JavaScript
+#### JavaScript
 
 Example of using the API from javascript:
 
@@ -188,7 +188,7 @@ fetch("https://www.vegvesen.no/trafikkdata/api/", {
   .catch(err => console.error(err));
 ```
 
-### curl
+#### curl
 
 Example of using the API from `curl`:
 

--- a/docs/api/3-terms-and-conditions.md
+++ b/docs/api/3-terms-and-conditions.md
@@ -1,4 +1,4 @@
-# Terms and conditions
+## Terms and conditions
 
 Data available through the Traffic Data API is licensed under [the Norwegian Licence for Open Government Data (NLOD)](https://data.norge.no/nlod/en/). This includes, but is not limited to, the following terms and conditions. For further details, please refer to the complete licence.
 
@@ -8,7 +8,6 @@ You are allowed to:
 - modify data and/or combine data with other data sets,
 - copy and distribute such changed or combined data,
 - use the data commercially.
-
 
 ### Use of data quality parameters and disclaimer of liability
 
@@ -20,14 +19,12 @@ The NPRA disclaims any liability for errors and defects associated with the info
 
 The NPRA shall not be liable for direct or indirect losses as a result of use of the information or in connection with copying or further distribution of the data.
 
-
 ### Attribution
 
 All use of data from the API shall be attributed the Norwegian Public Roads Administration (NPRA) (Norwegian: Statens vegvesen) as suggested below, but not in a way that indicates the NPRA has approved or recommended you or your use of the data set.
 
 Data shall not be used in a manner that appears misleading nor presented in a distorted or incorrect manner.
 
-Example of attribution: 
+Example of attribution:
 
 «Contains data under the Norwegian licence for Open Government data (NLOD) distributed by the Norwegian Public Roads Administration.»
-

--- a/docs/api/4-contact.md
+++ b/docs/api/4-contact.md
@@ -1,5 +1,4 @@
-
-# Contact
+## Contact
 
 If you use our data in an application, we would love to hear about it.
-Feel free to contact us at [trafikkdata@vegvesen.no](mailto:trafikkdata@vegvesen.no?subject=About%20Traffic%20Data%20API) with questions, suggestions and to tell us how you use the data. 
+Feel free to contact us at [trafikkdata@vegvesen.no](mailto:trafikkdata@vegvesen.no?subject=About%20Traffic%20Data%20API) with questions, suggestions and to tell us how you use the data.

--- a/docs/api/5-changelog.md
+++ b/docs/api/5-changelog.md
@@ -1,12 +1,12 @@
-# Changelog
+## Changelog
 
 All notable changes to the API will be documented here.
 
-## 13-12-2022
+### 13-12-2022
 
 No breaking changes, only additions and deprecations. The deprecated fields will be removed on 15.06.2023 at the earliest.
 
-### Lane numbers and traffic directions according to road link direction
+#### Lane numbers and traffic directions according to road link direction
 
 Added field `Lane.laneNumberAccordingToRoadLink`. It is now possible to retrieve lanes numbered according to the road link direction. (Traffic in odd-numbered lanes travels with the road link direction, while traffic in even-numbered lanes travels against the road link direction.) This matches the lane numbers used by NVDB, and they do not change over time. `Lane.laneNumberAccordingToMetering` is still available as before, with lane numbers according to the road's current metering direction. `Lane.laneNumber`is now deprecated, as its meaning is ambiguous.
 
@@ -14,28 +14,28 @@ Similarly `Direction.fromAccordingToRoadLink` and `Direction.toAccordingToRoadLi
 
 `TrafficRegistrationPoint.meteringDirectionChanged` has also been deprecated. It should not be relevant to API consumers anymore, thanks to the new fields described above.
 
-## 10-03-2021
+### 10-03-2021
 
 **Breaking changes to the API.** Several fields will be made nullable on March 22, 2021. Two deprecated fields will be removed.
 
 In the coming months, the Traffic Data API will be extended with historical data from the period 1996 - 2019. This dataset has slight differences compared to the traffic data that is currently available. Unfortunately, this requires making a few breaking changes to the GraphQL API. The API schema will be updated to reflect the below changes on the 22th of March, with historical aggregates becoming available gradually in the months following. Hour and day aggregates are due first, then average volumes.
 
-### Nullable coverage
+#### Nullable coverage
 
 Coverage &mdash; a metric describing the quality and completeness of the traffic data aggregates &mdash; does not exist for the historical data from this period and will always be `null`. Therefore, a breaking schema change will be made where the `coverage` field is made nullable for all average types under `trafficData > volume > average`. This field is already nullable for hour and day aggregates.
 
-### Nullable validSpeed and validLength
+#### Nullable validSpeed and validLength
 
 Similarly, the `validSpeed`, `validLength`, `validSpeedVolume` and `validLengthVolume` fields will be made nullable, as these were also not computed for the historical data. This affects all aggregates and averages, including hour and day aggregates.
 
-### New length range class
+#### New length range class
 
 The historical data has slightly different length ranges classes compared to the current data. The difference is in the upper range, where the historical data uses the length range class `[16.0, ...)`. The aggregates associated with this class are conceptually equal to the sum of the current `[16.0, 24.0)` and `[24.0, ...)` aggregates. The two latter classes are not present in the historical data. This change entails that the set of length range classes returned from the API can now be heterogenous: data for the historical period in time will use the old classes, while current traffic data will continue to use the same classes as before.
 
-### Removing deprecated fields
+#### Removing deprecated fields
 
 The `validSpeedRatio` and `validLengthRatio` fields for hour and day aggregates have been deprecated for more than a year and will now be removed. Use of these fields should be replaced with `volumeNumbers > validSpeed` and `volumeNumbers > validLength`.
 
-## 26-02-2021
+### 26-02-2021
 
 Changes to the Trafikkdata API will be published here. In addition the changes will be availible on the Twitter account [@VegvesenData](https://twitter.com/vegvesendata).


### PR DESCRIPTION
Increased all heading levels by one in order to obtain only a single h1 tag on a page. All markdown pages in the Portal already contains an h1-tag, hence markdown files should only have the biggest heading as h2 (equals to "##" in markdown). 

Added a configuration file for .markdownlint plugin, and disabled the rule MD041, which complains when a file does not start with a primary heading "#". 