### PR TITLE
underline links UU

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ Problems, questions or feedback to the Trafikkdata API or website? Create an <in
 
 Following is the documentation that is also available on trafikkdata.no.
 
-### <ins>[Om Trafikkdata.no](docs/about/1-om-trafikkdata.md)
+### <ins>[Om Trafikkdata.no](docs/about/1-om-trafikkdata.md)</ins>
 
-- <ins>[Datakvalitet](docs/about/2-datakvalitet.md)
-- <ins>[Beregningsmetodikk](docs/about/3-beregningsmetodikk.md)
-- <ins>[Om eksport](docs/about/4-om-eksport.md)
-- <ins>[Endringslogg](docs/about/5-endringslogg.md)
+- <ins>[Datakvalitet](docs/about/2-datakvalitet.md)</ins>
+- <ins>[Beregningsmetodikk](docs/about/3-beregningsmetodikk.md)</ins>
+- <ins>[Om eksport](docs/about/4-om-eksport.md)</ins>
+- <ins>[Endringslogg](docs/about/5-endringslogg.md)</ins>
 
-### <ins>[About API](docs/api/1-about-API.md)
+### <ins>[About API](docs/api/1-about-API.md)</ins>
 
-- <ins>[Usage](docs/api/2-usage.md)
-- <ins>[Terms and conditions](docs/api/3-terms-and-conditions.md)
-- <ins>[Contact](docs/api/4-contact.md)
-- <ins>[Changelog](docs/api/5-changelog.md)
+- <ins>[Usage](docs/api/2-usage.md)</ins>
+- <ins>[Terms and conditions](docs/api/3-terms-and-conditions.md)</ins>
+- <ins>[Contact](docs/api/4-contact.md)</ins>
+- <ins>[Changelog](docs/api/5-changelog.md)</ins>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # 🗺️ Trafikkdata.no
 
-This repository contains documentation and changelog for the <ins>[Trafikkdata API](https://trafikkdata-api.atlas.vegvesen.no), documentation for the <ins>[Trafikkdata.no](https://www.vegvesen.no/trafikkdata/) </ins> website, and information about the trafikkdata domain.
+This repository contains documentation and changelog for the <ins>[Trafikkdata API](https://trafikkdata-api.atlas.vegvesen.no) </ins>, documentation for the <ins>[Trafikkdata.no](https://www.vegvesen.no/trafikkdata/) </ins> website, and information about the trafikkdata domain.
 
 ## 💬 Feedback
 
-Problems, questions or feedback to the Trafikkdata API or website? Create an <ins>[issue](https://github.com/trafikkdata/trafikkdata.no-dokumentasjon/issues), and let us know what's on your mind.
+Problems, questions or feedback to the Trafikkdata API or website? Create an <ins>[issue](https://github.com/trafikkdata/trafikkdata.no-dokumentasjon/issues) </ins>, and let us know what's on your mind.
 
 ## 📝 Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # 🗺️ Trafikkdata.no
 
-This repository contains documentation and changelog for the <ins>[Trafikkdata API](https://trafikkdata-api.atlas.vegvesen.no) </ins>, documentation for the <ins>[Trafikkdata.no](https://www.vegvesen.no/trafikkdata/) </ins> website, and information about the trafikkdata domain.
+This repository contains documentation and changelog for the <ins>[Trafikkdata API](https://trafikkdata-api.atlas.vegvesen.no)</ins>, documentation for the <ins>[Trafikkdata.no](https://www.vegvesen.no/trafikkdata/)</ins> website, and information about the trafikkdata domain.
 
 ## 💬 Feedback
 
-Problems, questions or feedback to the Trafikkdata API or website? Create an <ins>[issue](https://github.com/trafikkdata/trafikkdata.no-dokumentasjon/issues) </ins>, and let us know what's on your mind.
+Problems, questions or feedback to the Trafikkdata API or website? Create an <ins>[issue](https://github.com/trafikkdata/trafikkdata.no-dokumentasjon/issues)</ins>, and let us know what's on your mind.
 
 ## 📝 Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # 🗺️ Trafikkdata.no
 
-This repository contains documentation and changelog for the <ins>[Trafikkdata API](https://trafikkdata-api.atlas.vegvesen.no)</ins>, documentation for the <ins>[Trafikkdata.no](https://www.vegvesen.no/trafikkdata/)</ins> website, and information about the trafikkdata domain.
+This repository contains documentation and changelog for the <a href="https://trafikkdata-api.atlas.vegvesen.no"  style="color: #44f55; text-decoration: underline;">Trafikkdata API</a>, documentation for the <a href="https://www.vegvesen.no/trafikkdata/"  style="color: #44f55; text-decoration: underline;">Trafikkdata.no</a> website, and information about the trafikkdata domain.
 
 ## 💬 Feedback
 
-Problems, questions or feedback to the Trafikkdata API or website? Create an <ins>[issue](https://github.com/trafikkdata/trafikkdata.no-dokumentasjon/issues)</ins>, and let us know what's on your mind.
+Problems, questions or feedback to the Trafikkdata API or website? Create an <a href="https://github.com/trafikkdata/trafikkdata.no-dokumentasjon/issues"  style="color: #44f55; text-decoration: underline;">issue</a>, and let us know what's on your mind.
 
 ## 📝 Documentation
 
 Following is the documentation that is also available on trafikkdata.no.
 
-### <ins>[Om Trafikkdata.no](docs/about/1-om-trafikkdata.md)</ins>
+### <a href="docs/about/1-om-trafikkdata.md"  style="color: #44f55; text-decoration: underline;">Om Trafikkdata.no</a>
 
-- <ins>[Datakvalitet](docs/about/2-datakvalitet.md)</ins>
-- <ins>[Beregningsmetodikk](docs/about/3-beregningsmetodikk.md)</ins>
-- <ins>[Om eksport](docs/about/4-om-eksport.md)</ins>
-- <ins>[Endringslogg](docs/about/5-endringslogg.md)</ins>
+- <a href="docs/about/2-datakvalitet.md"  style="color: #44f55; text-decoration: underline;">Datakvalitet</a>
+- <a href="docs/about/3-beregningsmetodikk.md"  style="color: #44f55; text-decoration: underline;">Beregningsmetodikk</a>
+- <a href="docs/about/4-om-eksport.md"  style="color: #44f55; text-decoration: underline;">Om eksport</a>
+- <a href="docs/about/5-endringslogg.md"  style="color: #44f55; text-decoration: underline;">Endringslogg</a>
 
-### <ins>[About API](docs/api/1-about-API.md)</ins>
+### <a href="docs/api/1-about-API.md"  style="color: #44f55; text-decoration: underline;">About API</a>
 
-- <ins>[Usage](docs/api/2-usage.md)</ins>
-- <ins>[Terms and conditions](docs/api/3-terms-and-conditions.md)</ins>
-- <ins>[Contact](docs/api/4-contact.md)</ins>
-- <ins>[Changelog](docs/api/5-changelog.md)</ins>
+- <a href="docs/api/2-usage.md"  style="color: #44f55; text-decoration: underline;">Usage</a>
+- <a href="docs/api/3-terms-and-conditions.md"  style="color: #44f55; text-decoration: underline;">Terms and conditions</a>
+- <a href="docs/api/4-contact.md"  style="color: #44f55; text-decoration: underline;">Contact</a>
+- <a href="docs/api/5-changelog.md"  style="color: #44f55; text-decoration: underline;">Changelog</a>

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # 🗺️ Trafikkdata.no
 
-This repository contains documentation and changelog for the [Trafikkdata API](https://trafikkdata-api.atlas.vegvesen.no), documentation for the [Trafikkdata.no](https://www.vegvesen.no/trafikkdata/) website, and information about the trafikkdata domain.
+This repository contains documentation and changelog for the <ins>[Trafikkdata API](https://trafikkdata-api.atlas.vegvesen.no), documentation for the <ins>[Trafikkdata.no](https://www.vegvesen.no/trafikkdata/) </ins> website, and information about the trafikkdata domain.
 
 ## 💬 Feedback
 
-Problems, questions or feedback to the Trafikkdata API or website? Create an [issue](https://github.com/trafikkdata/trafikkdata.no-dokumentasjon/issues), and let us know what's on your mind.
+Problems, questions or feedback to the Trafikkdata API or website? Create an <ins>[issue](https://github.com/trafikkdata/trafikkdata.no-dokumentasjon/issues), and let us know what's on your mind.
 
 ## 📝 Documentation
 
 Following is the documentation that is also available on trafikkdata.no.
 
-### [Om Trafikkdata.no](docs/about/1-om-trafikkdata.md)
+### <ins>[Om Trafikkdata.no](docs/about/1-om-trafikkdata.md)
 
-- [Datakvalitet](docs/about/2-datakvalitet.md)
-- [Beregningsmetodikk](docs/about/3-beregningsmetodikk.md)
-- [Om eksport](docs/about/4-om-eksport.md)
-- [Endringslogg](docs/about/5-endringslogg.md)
+- <ins>[Datakvalitet](docs/about/2-datakvalitet.md)
+- <ins>[Beregningsmetodikk](docs/about/3-beregningsmetodikk.md)
+- <ins>[Om eksport](docs/about/4-om-eksport.md)
+- <ins>[Endringslogg](docs/about/5-endringslogg.md)
 
-### [About API](docs/api/1-about-API.md)
+### <ins>[About API](docs/api/1-about-API.md)
 
-- [Usage](docs/api/2-usage.md)
-- [Terms and conditions](docs/api/3-terms-and-conditions.md)
-- [Contact](docs/api/4-contact.md)
-- [Changelog](docs/api/5-changelog.md)
+- <ins>[Usage](docs/api/2-usage.md)
+- <ins>[Terms and conditions](docs/api/3-terms-and-conditions.md)
+- <ins>[Contact](docs/api/4-contact.md)
+- <ins>[Changelog](docs/api/5-changelog.md)

--- a/docs/about/1-om-trafikkdata.md
+++ b/docs/about/1-om-trafikkdata.md
@@ -1,4 +1,4 @@
-Trafikkdata er data om trafikk på vegnettet. Statens vegvesens trafikkdata omfatter punktmålinger og strekningsmålinger foretatt med måleutstyr langs vegen. [Trafikkdata.no](http://trafikkdata.no) har punktmålinger fra trafikkregistreringsstasjoner på det statlige og fylkeskommunale vegnettet samt noen kommunale veger. [Vegvesen.no/trafikk](https://vegvesen.no/trafikk/) har strekningsmålinger av reisetid mellom reisetidsregistreringsstasjoner i og rundt de største byene og på noen hovedveger.
+Trafikkdata er data om trafikk på vegnettet. Statens vegvesens trafikkdata omfatter punktmålinger og strekningsmålinger foretatt med måleutstyr langs vegen. <ins>[Trafikkdata.no](http://trafikkdata.no) </ins> har punktmålinger fra trafikkregistreringsstasjoner på det statlige og fylkeskommunale vegnettet samt noen kommunale veger. <ins>[Vegvesen.no/trafikk](https://vegvesen.no/trafikk/) </ins> har strekningsmålinger av reisetid mellom reisetidsregistreringsstasjoner i og rundt de største byene og på noen hovedveger.
 
 Statens vegvesen har som mål å kunne levere trafikkdata med kjent kvalitet og riktig detaljeringsgrad, samt at disse dataene er etterspurt og samlet fra riktig vegnett.
 
@@ -6,7 +6,7 @@ Trafikkregistreringsstasjonene registrerer både sykler og motorkjøretøy. I sy
 
 Trafikkregistreringsstasjoner har ett eller flere trafikkregistreringspunkter knyttet til seg. Trafikkregistreringspunkter er stedfesting på vegen der trafikken blir registrert, og all informasjon om trafikkregistreringspunktene og tilhørende trafikkdata er tilgjengelige her i trafikkdataportalen.
 
-Trafikkregistreringsstasjoner består av fysisk infrastruktur ved vegen, som skap o.l. Informasjon om disse kan være relevant for de som drifter og vedlikeholder veg og tilknyttet infrastruktur, og er tilgjengelig i NVDB, se for eksempel [vegkart.no](http://vegkart.no).
+Trafikkregistreringsstasjoner består av fysisk infrastruktur ved vegen, som skap o.l. Informasjon om disse kan være relevant for de som drifter og vedlikeholder veg og tilknyttet infrastruktur, og er tilgjengelig i NVDB, se for eksempel <ins>[vegkart.no](http://vegkart.no). </ins> 
 
 ### Motorkjøretøy
 
@@ -46,7 +46,7 @@ Alle trafikkregistreringspunkter er stedfestet på vegnettet med en vegsystemref
 
 Trafikken registreres i hvert kjørefelt, som benevnes med et kjørefeltnummer. Kjørefeltene nummereres fra midten av vegen og utover til hver side. Det brukes oddetall på felt som har kjøreretning med metreringsretningen, og partall på kjørefelt mot metreringsretningen.
 
-For mer detaljer om vegsystemreferansen, se Statens vegvesens Håndbok V830 Nasjonalt vegreferansesystem, som er tilgjengelig på [vegvesen.no](https://www.vegvesen.no/fag/publikasjoner/handboker).
+For mer detaljer om vegsystemreferansen, se Statens vegvesens Håndbok V830 Nasjonalt vegreferansesystem, som er tilgjengelig på <ins>[vegvesen.no](https://www.vegvesen.no/fag/publikasjoner/handboker). </ins> 
 
 #### Kjørefeltnummer ved snudd metreringsretning
 

--- a/docs/about/1-om-trafikkdata.md
+++ b/docs/about/1-om-trafikkdata.md
@@ -53,5 +53,3 @@ For mer detaljer om vegsystemreferansen, se Statens vegvesens Håndbok V830 Nasj
 Vegsystemreferansen endrer seg når selve vegnettet endrer seg, som ved bygging av ny veg. Retningen som vegen er oppmålt i kan snus, og dette har skjedd i en del tilfeller i forbindelse med innføring av nytt vegreferansesystem i 2019. Endret metreringsretning medfører at kjørefeltnummer også endrer seg. I Trafikkdataportalen vises alltid kjørefeltnummer i henhold til nåværende metrering, også for historiske data. Kjørefeltenes beskrivelser med stedsnavn vil alltid være korrekt og uendret for det fysiske kjørefeltet, selv om nummeret har endret seg.
 
 Trafikkregistreringspunktenes vegreferansehistorikk angir periodene hvor metreringsretningen er snudd siden første gang punktet ble satt i drift.
-
-<a href="https://www.google.com/" style="color: black; text-decoration: underline;text-decoration-style: dotted;">custom link</a>

--- a/docs/about/1-om-trafikkdata.md
+++ b/docs/about/1-om-trafikkdata.md
@@ -1,4 +1,4 @@
-Trafikkdata er data om trafikk på vegnettet. Statens vegvesens trafikkdata omfatter punktmålinger og strekningsmålinger foretatt med måleutstyr langs vegen. <ins>[Trafikkdata.no](http://trafikkdata.no) </ins> har punktmålinger fra trafikkregistreringsstasjoner på det statlige og fylkeskommunale vegnettet samt noen kommunale veger. <ins>[Vegvesen.no/trafikk](https://vegvesen.no/trafikk/) </ins> har strekningsmålinger av reisetid mellom reisetidsregistreringsstasjoner i og rundt de største byene og på noen hovedveger.
+Trafikkdata er data om trafikk på vegnettet. Statens vegvesens trafikkdata omfatter punktmålinger og strekningsmålinger foretatt med måleutstyr langs vegen. <ins>[Trafikkdata.no](http://trafikkdata.no)</ins> har punktmålinger fra trafikkregistreringsstasjoner på det statlige og fylkeskommunale vegnettet samt noen kommunale veger. <ins>[Vegvesen.no/trafikk](https://vegvesen.no/trafikk/)</ins> har strekningsmålinger av reisetid mellom reisetidsregistreringsstasjoner i og rundt de største byene og på noen hovedveger.
 
 Statens vegvesen har som mål å kunne levere trafikkdata med kjent kvalitet og riktig detaljeringsgrad, samt at disse dataene er etterspurt og samlet fra riktig vegnett.
 
@@ -6,7 +6,7 @@ Trafikkregistreringsstasjonene registrerer både sykler og motorkjøretøy. I sy
 
 Trafikkregistreringsstasjoner har ett eller flere trafikkregistreringspunkter knyttet til seg. Trafikkregistreringspunkter er stedfesting på vegen der trafikken blir registrert, og all informasjon om trafikkregistreringspunktene og tilhørende trafikkdata er tilgjengelige her i trafikkdataportalen.
 
-Trafikkregistreringsstasjoner består av fysisk infrastruktur ved vegen, som skap o.l. Informasjon om disse kan være relevant for de som drifter og vedlikeholder veg og tilknyttet infrastruktur, og er tilgjengelig i NVDB, se for eksempel <ins>[vegkart.no](http://vegkart.no). </ins> 
+Trafikkregistreringsstasjoner består av fysisk infrastruktur ved vegen, som skap o.l. Informasjon om disse kan være relevant for de som drifter og vedlikeholder veg og tilknyttet infrastruktur, og er tilgjengelig i NVDB, se for eksempel <ins>[vegkart.no](http://vegkart.no)</ins>. 
 
 ### Motorkjøretøy
 
@@ -46,7 +46,7 @@ Alle trafikkregistreringspunkter er stedfestet på vegnettet med en vegsystemref
 
 Trafikken registreres i hvert kjørefelt, som benevnes med et kjørefeltnummer. Kjørefeltene nummereres fra midten av vegen og utover til hver side. Det brukes oddetall på felt som har kjøreretning med metreringsretningen, og partall på kjørefelt mot metreringsretningen.
 
-For mer detaljer om vegsystemreferansen, se Statens vegvesens Håndbok V830 Nasjonalt vegreferansesystem, som er tilgjengelig på <ins>[vegvesen.no](https://www.vegvesen.no/fag/publikasjoner/handboker). </ins> 
+For mer detaljer om vegsystemreferansen, se Statens vegvesens Håndbok V830 Nasjonalt vegreferansesystem, som er tilgjengelig på <ins>[vegvesen.no](https://www.vegvesen.no/fag/publikasjoner/handboker)</ins>. 
 
 #### Kjørefeltnummer ved snudd metreringsretning
 

--- a/docs/about/1-om-trafikkdata.md
+++ b/docs/about/1-om-trafikkdata.md
@@ -1,4 +1,4 @@
-Trafikkdata er data om trafikk på vegnettet. Statens vegvesens trafikkdata omfatter punktmålinger og strekningsmålinger foretatt med måleutstyr langs vegen. <ins>[Trafikkdata.no](http://trafikkdata.no)</ins> har punktmålinger fra trafikkregistreringsstasjoner på det statlige og fylkeskommunale vegnettet samt noen kommunale veger. <ins>[Vegvesen.no/trafikk](https://vegvesen.no/trafikk/)</ins> har strekningsmålinger av reisetid mellom reisetidsregistreringsstasjoner i og rundt de største byene og på noen hovedveger.
+Trafikkdata er data om trafikk på vegnettet. Statens vegvesens trafikkdata omfatter punktmålinger og strekningsmålinger foretatt med måleutstyr langs vegen. <a href="http://trafikkdata.no"  style="color: #44f55; text-decoration: underline;">Trafikkdata.no</a> har punktmålinger fra trafikkregistreringsstasjoner på det statlige og fylkeskommunale vegnettet samt noen kommunale veger. <a href="https://vegvesen.no/trafikk/"  style="color: #44f55; text-decoration: underline;">Vegvesen.no/trafikk</a> har strekningsmålinger av reisetid mellom reisetidsregistreringsstasjoner i og rundt de største byene og på noen hovedveger.
 
 Statens vegvesen har som mål å kunne levere trafikkdata med kjent kvalitet og riktig detaljeringsgrad, samt at disse dataene er etterspurt og samlet fra riktig vegnett.
 
@@ -6,7 +6,7 @@ Trafikkregistreringsstasjonene registrerer både sykler og motorkjøretøy. I sy
 
 Trafikkregistreringsstasjoner har ett eller flere trafikkregistreringspunkter knyttet til seg. Trafikkregistreringspunkter er stedfesting på vegen der trafikken blir registrert, og all informasjon om trafikkregistreringspunktene og tilhørende trafikkdata er tilgjengelige her i trafikkdataportalen.
 
-Trafikkregistreringsstasjoner består av fysisk infrastruktur ved vegen, som skap o.l. Informasjon om disse kan være relevant for de som drifter og vedlikeholder veg og tilknyttet infrastruktur, og er tilgjengelig i NVDB, se for eksempel <ins>[vegkart.no](http://vegkart.no)</ins>. 
+Trafikkregistreringsstasjoner består av fysisk infrastruktur ved vegen, som skap o.l. Informasjon om disse kan være relevant for de som drifter og vedlikeholder veg og tilknyttet infrastruktur, og er tilgjengelig i NVDB, se for eksempel <a href="http://vegkart.no"  style="color: #44f55; text-decoration: underline;">vegkart.no</a>. 
 
 ### Motorkjøretøy
 
@@ -46,7 +46,7 @@ Alle trafikkregistreringspunkter er stedfestet på vegnettet med en vegsystemref
 
 Trafikken registreres i hvert kjørefelt, som benevnes med et kjørefeltnummer. Kjørefeltene nummereres fra midten av vegen og utover til hver side. Det brukes oddetall på felt som har kjøreretning med metreringsretningen, og partall på kjørefelt mot metreringsretningen.
 
-For mer detaljer om vegsystemreferansen, se Statens vegvesens Håndbok V830 Nasjonalt vegreferansesystem, som er tilgjengelig på <ins>[vegvesen.no](https://www.vegvesen.no/fag/publikasjoner/handboker)</ins>. 
+For mer detaljer om vegsystemreferansen, se Statens vegvesens Håndbok V830 Nasjonalt vegreferansesystem, som er tilgjengelig på <a href="https://www.vegvesen.no/fag/publikasjoner/handboker"  style="color: #44f55; text-decoration: underline;">vegvesen.no</a>. 
 
 #### Kjørefeltnummer ved snudd metreringsretning
 

--- a/docs/about/1-om-trafikkdata.md
+++ b/docs/about/1-om-trafikkdata.md
@@ -53,3 +53,5 @@ For mer detaljer om vegsystemreferansen, se Statens vegvesens Håndbok V830 Nasj
 Vegsystemreferansen endrer seg når selve vegnettet endrer seg, som ved bygging av ny veg. Retningen som vegen er oppmålt i kan snus, og dette har skjedd i en del tilfeller i forbindelse med innføring av nytt vegreferansesystem i 2019. Endret metreringsretning medfører at kjørefeltnummer også endrer seg. I Trafikkdataportalen vises alltid kjørefeltnummer i henhold til nåværende metrering, også for historiske data. Kjørefeltenes beskrivelser med stedsnavn vil alltid være korrekt og uendret for det fysiske kjørefeltet, selv om nummeret har endret seg.
 
 Trafikkregistreringspunktenes vegreferansehistorikk angir periodene hvor metreringsretningen er snudd siden første gang punktet ble satt i drift.
+
+<a href="https://www.google.com/" style="color: black; text-decoration: underline;text-decoration-style: dotted;">custom link</a>

--- a/docs/about/4-om-fartsdata.md
+++ b/docs/about/4-om-fartsdata.md
@@ -16,7 +16,7 @@ Under er en oversikt over hvordan du skal gå frem for å få tilgang til fartsd
 
 For deg som er ansatt i Statens Vegvesen.
 
-- Logg inn på <ins>[selvbetjeningsportalen](https://www.vegvesen.no/idportalen/selvbetjening/) </ins> for tilganger og søk om enten “Trafikkdata – Fart – Alle veier” eller “Trafikkdata – Fart – Riksveier” etter tjenstlig behov
+- Logg inn på <ins>[selvbetjeningsportalen](https://www.vegvesen.no/idportalen/selvbetjening/)</ins> for tilganger og søk om enten “Trafikkdata – Fart – Alle veier” eller “Trafikkdata – Fart – Riksveier” etter tjenstlig behov
 - Logg inn og ta fartsdata i bruk
 
 #### For andre vegeiere

--- a/docs/about/4-om-fartsdata.md
+++ b/docs/about/4-om-fartsdata.md
@@ -16,7 +16,7 @@ Under er en oversikt over hvordan du skal gå frem for å få tilgang til fartsd
 
 For deg som er ansatt i Statens Vegvesen.
 
-- Logg inn på <ins>[selvbetjeningsportalen](https://www.vegvesen.no/idportalen/selvbetjening/)</ins> for tilganger og søk om enten “Trafikkdata – Fart – Alle veier” eller “Trafikkdata – Fart – Riksveier” etter tjenstlig behov
+- Logg inn på <a href="https://www.vegvesen.no/idportalen/selvbetjening/"  style="color: #44f55; text-decoration: underline;">selvbetjeningsportalen</a> for tilganger og søk om enten “Trafikkdata – Fart – Alle veier” eller “Trafikkdata – Fart – Riksveier” etter tjenstlig behov
 - Logg inn og ta fartsdata i bruk
 
 #### For andre vegeiere

--- a/docs/about/4-om-fartsdata.md
+++ b/docs/about/4-om-fartsdata.md
@@ -16,7 +16,7 @@ Under er en oversikt over hvordan du skal gå frem for å få tilgang til fartsd
 
 For deg som er ansatt i Statens Vegvesen.
 
-- Logg inn på [selvbetjeningsportalen](https://www.vegvesen.no/idportalen/selvbetjening/) for tilganger og søk om enten “Trafikkdata – Fart – Alle veier” eller “Trafikkdata – Fart – Riksveier” etter tjenstlig behov
+- Logg inn på <ins>[selvbetjeningsportalen](https://www.vegvesen.no/idportalen/selvbetjening/) </ins> for tilganger og søk om enten “Trafikkdata – Fart – Alle veier” eller “Trafikkdata – Fart – Riksveier” etter tjenstlig behov
 - Logg inn og ta fartsdata i bruk
 
 #### For andre vegeiere

--- a/docs/about/6-endringslogg.md
+++ b/docs/about/6-endringslogg.md
@@ -17,4 +17,4 @@ CSV-eksport: kolonne-overskriften "Volum" endres til "Trafikkmengde". Eventuelle
 
 ### 24.02.2021
 
-Endringer på Trafikkdata.no vil publiseres her, i tillegg til å bli publisert på Twitter-kontoen [@VegvesenData](https://twitter.com/vegvesendata).
+Endringer på Trafikkdata.no vil publiseres her, i tillegg til å bli publisert på Twitter-kontoen <ins>[@VegvesenData](https://twitter.com/vegvesendata). </ins> 

--- a/docs/about/6-endringslogg.md
+++ b/docs/about/6-endringslogg.md
@@ -17,4 +17,4 @@ CSV-eksport: kolonne-overskriften "Volum" endres til "Trafikkmengde". Eventuelle
 
 ### 24.02.2021
 
-Endringer på Trafikkdata.no vil publiseres her, i tillegg til å bli publisert på Twitter-kontoen <ins>[@VegvesenData](https://twitter.com/vegvesendata)</ins>. 
+Endringer på Trafikkdata.no vil publiseres her, i tillegg til å bli publisert på Twitter-kontoen <a href="https://twitter.com/vegvesendata"  style="color: #44f55; text-decoration: underline;">@VegvesenData</a>. 

--- a/docs/about/6-endringslogg.md
+++ b/docs/about/6-endringslogg.md
@@ -17,4 +17,4 @@ CSV-eksport: kolonne-overskriften "Volum" endres til "Trafikkmengde". Eventuelle
 
 ### 24.02.2021
 
-Endringer på Trafikkdata.no vil publiseres her, i tillegg til å bli publisert på Twitter-kontoen <ins>[@VegvesenData](https://twitter.com/vegvesendata). </ins> 
+Endringer på Trafikkdata.no vil publiseres her, i tillegg til å bli publisert på Twitter-kontoen <ins>[@VegvesenData](https://twitter.com/vegvesendata)</ins>. 

--- a/docs/about/8-tilgjengelighet.md
+++ b/docs/about/8-tilgjengelighet.md
@@ -1,3 +1,3 @@
 ## Tilgjengelighet
 
-Denne nettsiden har blitt vurdert opp mot gjeldende WCAG-krav for universell utforming. Du kan finne <ins>[tilgjengelighetserklæringen (2023) her](https://uustatus.no/nb/erklaringer/publisert/52679a09-4af7-486f-87b5-49986439711a).
+Denne nettsiden har blitt vurdert opp mot gjeldende WCAG-krav for universell utforming. Du kan finne <ins>[tilgjengelighetserklæringen (2023) her](https://uustatus.no/nb/erklaringer/publisert/52679a09-4af7-486f-87b5-49986439711a)</ins>.

--- a/docs/about/8-tilgjengelighet.md
+++ b/docs/about/8-tilgjengelighet.md
@@ -1,3 +1,3 @@
 ## Tilgjengelighet
 
-Denne nettsiden har blitt vurdert opp mot gjeldende WCAG-krav for universell utforming. Du kan finne <ins>[tilgjengelighetserklæringen (2023) her](https://uustatus.no/nb/erklaringer/publisert/52679a09-4af7-486f-87b5-49986439711a)</ins>.
+Denne nettsiden har blitt vurdert opp mot gjeldende WCAG-krav for universell utforming. Du kan finne <a href="https://uustatus.no/nb/erklaringer/publisert/52679a09-4af7-486f-87b5-49986439711a"  style="color: #44f55; text-decoration: underline;">tilgjengelighetserklæringen (2023) her</a>.

--- a/docs/about/8-tilgjengelighet.md
+++ b/docs/about/8-tilgjengelighet.md
@@ -1,3 +1,3 @@
 ## Tilgjengelighet
 
-Denne nettsiden har blitt vurdert opp mot gjeldende WCAG-krav for universell utforming. Du kan finne [tilgjengelighetserklæringen (2023) her](https://uustatus.no/nb/erklaringer/publisert/52679a09-4af7-486f-87b5-49986439711a).
+Denne nettsiden har blitt vurdert opp mot gjeldende WCAG-krav for universell utforming. Du kan finne <ins>[tilgjengelighetserklæringen (2023) her](https://uustatus.no/nb/erklaringer/publisert/52679a09-4af7-486f-87b5-49986439711a).

--- a/docs/api/1-about-API.md
+++ b/docs/api/1-about-API.md
@@ -11,4 +11,4 @@ The vehicles are classified according to their measured length.
 All data has quality parameters associated with it, indicating their uncertainty and relevance.
 All use of the data must take the quality parameters into account.
 
-Read more on traffic data and data quality under <ins>[Om trafikkdata (Norwegian only)](#/om-trafikkdata).
+Read more on traffic data and data quality under <ins>[Om trafikkdata (Norwegian only)](#/om-trafikkdata)</ins>.

--- a/docs/api/1-about-API.md
+++ b/docs/api/1-about-API.md
@@ -11,4 +11,4 @@ The vehicles are classified according to their measured length.
 All data has quality parameters associated with it, indicating their uncertainty and relevance.
 All use of the data must take the quality parameters into account.
 
-Read more on traffic data and data quality under [Om trafikkdata (Norwegian only)](#/om-trafikkdata).
+Read more on traffic data and data quality under <ins>[Om trafikkdata (Norwegian only)](#/om-trafikkdata).

--- a/docs/api/1-about-API.md
+++ b/docs/api/1-about-API.md
@@ -11,4 +11,4 @@ The vehicles are classified according to their measured length.
 All data has quality parameters associated with it, indicating their uncertainty and relevance.
 All use of the data must take the quality parameters into account.
 
-Read more on traffic data and data quality under <ins>[Om trafikkdata (Norwegian only)](#/om-trafikkdata)</ins>.
+Read more on traffic data and data quality under <a href="#/om-trafikkdata"  style="color: #44f55; text-decoration: underline;">Om trafikkdata (Norwegian only)</a>.

--- a/docs/api/2-usage.md
+++ b/docs/api/2-usage.md
@@ -1,22 +1,22 @@
 ## Usage
 
-The Traffic Data API is located at [https://trafikkdata-api.atlas.vegvesen.no](https://trafikkdata-api.atlas.vegvesen.no).
+The Traffic Data API is located at <ins>[https://trafikkdata-api.atlas.vegvesen.no](https://trafikkdata-api.atlas.vegvesen.no). </ins> 
 
 The API uses GraphQL, which is a data query language for APIs.
 It defines a schema composed of different types and fields on those types.
 It allows for introspection of the API and for creating strongly typed clients.
-For more general information on GraphQL, visit [graphql.org/learn](https://graphql.org/learn/).
+For more general information on GraphQL, visit <ins>[graphql.org/learn](https://graphql.org/learn/). </ins> 
 
 When opened in a web browser, the API is presented through GraphiQL, a graphical user interface for writing and executing queries.
 Queries can also be performed programatically from a wide range of programming languages.
-For more information, visit [graphql.org/code](https://graphql.org/code/).
+For more information, visit <ins>[graphql.org/code](https://graphql.org/code/). </ins> 
 
 In the following, we present a few examples of API queries.
-For full documentation of all available queries and fields, use the [GraphiQL interface](https://trafikkdata-api.atlas.vegvesen.no) and click on `Docs`.
+For full documentation of all available queries and fields, use the <ins>[GraphiQL interface](https://trafikkdata-api.atlas.vegvesen.no) </ins> and click on `Docs`.
 
 ### Traffic registration points
 
-A traffic registration point is a location on the road where traffic is registered. For more information, see [Om trafikkdata](om-trafikkdata).
+A traffic registration point is a location on the road where traffic is registered. For more information, see <ins>[Om trafikkdata](om-trafikkdata). </ins> 
 The `trafficRegistrationPoints` query allows users to list traffic registration points that satisfy certain criteria.
 
 The following example lists all traffic registration points on European routes, with traffic registration point ID, name and coordinates (WGS-84).

--- a/docs/api/2-usage.md
+++ b/docs/api/2-usage.md
@@ -1,22 +1,22 @@
 ## Usage
 
-The Traffic Data API is located at <ins>[https://trafikkdata-api.atlas.vegvesen.no](https://trafikkdata-api.atlas.vegvesen.no). </ins> 
+The Traffic Data API is located at <ins>[https://trafikkdata-api.atlas.vegvesen.no](https://trafikkdata-api.atlas.vegvesen.no)</ins>. 
 
 The API uses GraphQL, which is a data query language for APIs.
 It defines a schema composed of different types and fields on those types.
 It allows for introspection of the API and for creating strongly typed clients.
-For more general information on GraphQL, visit <ins>[graphql.org/learn](https://graphql.org/learn/). </ins> 
+For more general information on GraphQL, visit <ins>[graphql.org/learn](https://graphql.org/learn/)</ins>. 
 
 When opened in a web browser, the API is presented through GraphiQL, a graphical user interface for writing and executing queries.
 Queries can also be performed programatically from a wide range of programming languages.
-For more information, visit <ins>[graphql.org/code](https://graphql.org/code/). </ins> 
+For more information, visit <ins>[graphql.org/code](https://graphql.org/code/)</ins>. 
 
 In the following, we present a few examples of API queries.
-For full documentation of all available queries and fields, use the <ins>[GraphiQL interface](https://trafikkdata-api.atlas.vegvesen.no) </ins> and click on `Docs`.
+For full documentation of all available queries and fields, use the <ins>[GraphiQL interface](https://trafikkdata-api.atlas.vegvesen.no)</ins> and click on `Docs`.
 
 ### Traffic registration points
 
-A traffic registration point is a location on the road where traffic is registered. For more information, see <ins>[Om trafikkdata](om-trafikkdata). </ins> 
+A traffic registration point is a location on the road where traffic is registered. For more information, see <ins>[Om trafikkdata](om-trafikkdata)</ins>. 
 The `trafficRegistrationPoints` query allows users to list traffic registration points that satisfy certain criteria.
 
 The following example lists all traffic registration points on European routes, with traffic registration point ID, name and coordinates (WGS-84).

--- a/docs/api/2-usage.md
+++ b/docs/api/2-usage.md
@@ -1,22 +1,22 @@
 ## Usage
 
-The Traffic Data API is located at <ins>[https://trafikkdata-api.atlas.vegvesen.no](https://trafikkdata-api.atlas.vegvesen.no)</ins>. 
+The Traffic Data API is located at <a href="https://trafikkdata-api.atlas.vegvesen.no"  style="color: #44f55; text-decoration: underline;">https://trafikkdata-api.atlas.vegvesen.no</a>. 
 
 The API uses GraphQL, which is a data query language for APIs.
 It defines a schema composed of different types and fields on those types.
 It allows for introspection of the API and for creating strongly typed clients.
-For more general information on GraphQL, visit <ins>[graphql.org/learn](https://graphql.org/learn/)</ins>. 
+For more general information on GraphQL, visit <a href="https://graphql.org/learn/"  style="color: #44f55; text-decoration: underline;">graphql.org/learn</a>. 
 
 When opened in a web browser, the API is presented through GraphiQL, a graphical user interface for writing and executing queries.
 Queries can also be performed programatically from a wide range of programming languages.
-For more information, visit <ins>[graphql.org/code](https://graphql.org/code/)</ins>. 
+For more information, visit <a href="https://graphql.org/code/"  style="color: #44f55; text-decoration: underline;">graphql.org/code</a>. 
 
 In the following, we present a few examples of API queries.
-For full documentation of all available queries and fields, use the <ins>[GraphiQL interface](https://trafikkdata-api.atlas.vegvesen.no)</ins> and click on `Docs`.
+For full documentation of all available queries and fields, use the <a href="https://trafikkdata-api.atlas.vegvesen.no"  style="color: #44f55; text-decoration: underline;">GraphiQL interface</a> and click on `Docs`.
 
 ### Traffic registration points
 
-A traffic registration point is a location on the road where traffic is registered. For more information, see <ins>[Om trafikkdata](om-trafikkdata)</ins>. 
+A traffic registration point is a location on the road where traffic is registered. For more information, see <a href="om-trafikkdata"  style="color: #44f55; text-decoration: underline;">Om trafikkdata</a>. 
 The `trafficRegistrationPoints` query allows users to list traffic registration points that satisfy certain criteria.
 
 The following example lists all traffic registration points on European routes, with traffic registration point ID, name and coordinates (WGS-84).

--- a/docs/api/3-terms-and-conditions.md
+++ b/docs/api/3-terms-and-conditions.md
@@ -1,6 +1,6 @@
 ## Terms and conditions
 
-Data available through the Traffic Data API is licensed under <ins>[the Norwegian Licence for Open Government Data (NLOD)](https://data.norge.no/nlod/en/) </ins> This includes, but is not limited to, the following terms and conditions. For further details, please refer to the complete licence.
+Data available through the Traffic Data API is licensed under <ins>[the Norwegian Licence for Open Government Data (NLOD)](https://data.norge.no/nlod/en/)</ins> This includes, but is not limited to, the following terms and conditions. For further details, please refer to the complete licence.
 
 You are allowed to:
 

--- a/docs/api/3-terms-and-conditions.md
+++ b/docs/api/3-terms-and-conditions.md
@@ -1,6 +1,6 @@
 ## Terms and conditions
 
-Data available through the Traffic Data API is licensed under [the Norwegian Licence for Open Government Data (NLOD)](https://data.norge.no/nlod/en/). This includes, but is not limited to, the following terms and conditions. For further details, please refer to the complete licence.
+Data available through the Traffic Data API is licensed under <ins>[the Norwegian Licence for Open Government Data (NLOD)](https://data.norge.no/nlod/en/) </ins> This includes, but is not limited to, the following terms and conditions. For further details, please refer to the complete licence.
 
 You are allowed to:
 

--- a/docs/api/3-terms-and-conditions.md
+++ b/docs/api/3-terms-and-conditions.md
@@ -1,6 +1,6 @@
 ## Terms and conditions
 
-Data available through the Traffic Data API is licensed under <ins>[the Norwegian Licence for Open Government Data (NLOD)](https://data.norge.no/nlod/en/)</ins> This includes, but is not limited to, the following terms and conditions. For further details, please refer to the complete licence.
+Data available through the Traffic Data API is licensed under <a href="https://data.norge.no/nlod/en/"  style="color: #44f55; text-decoration: underline;">the Norwegian Licence for Open Government Data (NLOD)</a> This includes, but is not limited to, the following terms and conditions. For further details, please refer to the complete licence.
 
 You are allowed to:
 

--- a/docs/api/4-contact.md
+++ b/docs/api/4-contact.md
@@ -1,4 +1,4 @@
 ## Contact
 
 If you use our data in an application, we would love to hear about it.
-Feel free to contact us at [trafikkdata@vegvesen.no](mailto:trafikkdata@vegvesen.no?subject=About%20Traffic%20Data%20API) with questions, suggestions and to tell us how you use the data.
+Feel free to contact us at <ins>[trafikkdata@vegvesen.no](mailto:trafikkdata@vegvesen.no?subject=About%20Traffic%20Data%20API) </ins> with questions, suggestions and to tell us how you use the data.

--- a/docs/api/4-contact.md
+++ b/docs/api/4-contact.md
@@ -1,4 +1,4 @@
 ## Contact
 
 If you use our data in an application, we would love to hear about it.
-Feel free to contact us at <ins>[trafikkdata@vegvesen.no](mailto:trafikkdata@vegvesen.no?subject=About%20Traffic%20Data%20API)</ins> with questions, suggestions and to tell us how you use the data.
+Feel free to contact us at <a href="mailto:trafikkdata@vegvesen.no?subject=About%20Traffic%20Data%20API"  style="color: #44f55; text-decoration: underline;">trafikkdata@vegvesen.no</a> with questions, suggestions and to tell us how you use the data.

--- a/docs/api/4-contact.md
+++ b/docs/api/4-contact.md
@@ -1,4 +1,4 @@
 ## Contact
 
 If you use our data in an application, we would love to hear about it.
-Feel free to contact us at <ins>[trafikkdata@vegvesen.no](mailto:trafikkdata@vegvesen.no?subject=About%20Traffic%20Data%20API) </ins> with questions, suggestions and to tell us how you use the data.
+Feel free to contact us at <ins>[trafikkdata@vegvesen.no](mailto:trafikkdata@vegvesen.no?subject=About%20Traffic%20Data%20API)</ins> with questions, suggestions and to tell us how you use the data.

--- a/docs/api/5-changelog.md
+++ b/docs/api/5-changelog.md
@@ -31,7 +31,7 @@ The confidence interval in the API also utilizes the corrected standard error in
 
 ### 01-11-2023
 
-The [Trafikkdata API](https://trafikkdata-api.atlas.vegvesen.no) is now hosted on Atlas, and has been moved from [www.vegvesen.no/trafikkdata/api](https://www.vegvesen.no/trafikkdata/api) to [trafikkdata-api.atlas.vegvesen.no](https://trafikkdata-api.atlas.vegvesen.no).
+The <ins>[Trafikkdata API](https://trafikkdata-api.atlas.vegvesen.no) </ins> is now hosted on Atlas, and has been moved from <ins>[www.vegvesen.no/trafikkdata/api](https://www.vegvesen.no/trafikkdata/api) </ins> to <ins>[trafikkdata-api.atlas.vegvesen.no](https://trafikkdata-api.atlas.vegvesen.no). </ins> 
 
 Please use the new URL to access the **API**. The old URL is deprecated, and will no longer be available after **01.05.2024**.
 
@@ -79,4 +79,4 @@ The `validSpeedRatio` and `validLengthRatio` fields for hour and day aggregates 
 
 ### 26-02-2021
 
-Changes to the Trafikkdata API will be published here. In addition the changes will be availible on the Twitter account [@VegvesenData](https://twitter.com/vegvesendata).
+Changes to the Trafikkdata API will be published here. In addition the changes will be availible on the Twitter account <ins>[@VegvesenData](https://twitter.com/vegvesendata). </ins> 

--- a/docs/api/5-changelog.md
+++ b/docs/api/5-changelog.md
@@ -31,7 +31,7 @@ The confidence interval in the API also utilizes the corrected standard error in
 
 ### 01-11-2023
 
-The <ins>[Trafikkdata API](https://trafikkdata-api.atlas.vegvesen.no) </ins> is now hosted on Atlas, and has been moved from <ins>[www.vegvesen.no/trafikkdata/api](https://www.vegvesen.no/trafikkdata/api) </ins> to <ins>[trafikkdata-api.atlas.vegvesen.no](https://trafikkdata-api.atlas.vegvesen.no). </ins> 
+The <ins>[Trafikkdata API](https://trafikkdata-api.atlas.vegvesen.no)</ins> is now hosted on Atlas, and has been moved from <ins>[www.vegvesen.no/trafikkdata/api](https://www.vegvesen.no/trafikkdata/api)</ins> to <ins>[trafikkdata-api.atlas.vegvesen.no](https://trafikkdata-api.atlas.vegvesen.no)</ins>. 
 
 Please use the new URL to access the **API**. The old URL is deprecated, and will no longer be available after **01.05.2024**.
 
@@ -79,4 +79,4 @@ The `validSpeedRatio` and `validLengthRatio` fields for hour and day aggregates 
 
 ### 26-02-2021
 
-Changes to the Trafikkdata API will be published here. In addition the changes will be availible on the Twitter account <ins>[@VegvesenData](https://twitter.com/vegvesendata). </ins> 
+Changes to the Trafikkdata API will be published here. In addition the changes will be availible on the Twitter account <ins>[@VegvesenData](https://twitter.com/vegvesendata).</ins> 

--- a/docs/api/5-changelog.md
+++ b/docs/api/5-changelog.md
@@ -31,7 +31,7 @@ The confidence interval in the API also utilizes the corrected standard error in
 
 ### 01-11-2023
 
-The <ins>[Trafikkdata API](https://trafikkdata-api.atlas.vegvesen.no)</ins> is now hosted on Atlas, and has been moved from <ins>[www.vegvesen.no/trafikkdata/api](https://www.vegvesen.no/trafikkdata/api)</ins> to <ins>[trafikkdata-api.atlas.vegvesen.no](https://trafikkdata-api.atlas.vegvesen.no)</ins>. 
+The <a href="https://trafikkdata-api.atlas.vegvesen.no"  style="color: #44f55; text-decoration: underline;">Trafikkdata API</a> is now hosted on Atlas, and has been moved from <a href="https://www.vegvesen.no/trafikkdata/api"  style="color: #44f55; text-decoration: underline;">www.vegvesen.no/trafikkdata/api</a> to <a href="https://trafikkdata-api.atlas.vegvesen.no"  style="color: #44f55; text-decoration: underline;">trafikkdata-api.atlas.vegvesen.no</a>. 
 
 Please use the new URL to access the **API**. The old URL is deprecated, and will no longer be available after **01.05.2024**.
 
@@ -79,4 +79,4 @@ The `validSpeedRatio` and `validLengthRatio` fields for hour and day aggregates 
 
 ### 26-02-2021
 
-Changes to the Trafikkdata API will be published here. In addition the changes will be availible on the Twitter account <ins>[@VegvesenData](https://twitter.com/vegvesendata).</ins> 
+Changes to the Trafikkdata API will be published here. In addition the changes will be availible on the Twitter account <a href="https://twitter.com/vegvesendata"  style="color: #44f55; text-decoration: underline;">@VegvesenData.</a> 


### PR DESCRIPTION
The text looks double underlined in github (https://github.com/trafikkdata/trafikkdata.no-dokumentasjon/tree/have-links-underlined-UU).
This is because github renders the markdown differently. Github underlines any link automatically, while this is not the case when checking the same text on trafikkdata.no (About page for example). If you want to see how the markdown will actually look check out this sandbox: https://markdownlivepreview.com/  how it actually will look like)