### PR TITLE
Remove year from accessibility declaration link text

### DIFF
--- a/docs/about/8-tilgjengelighet.md
+++ b/docs/about/8-tilgjengelighet.md
@@ -1,3 +1,3 @@
 ## Tilgjengelighet
 
-Denne nettsiden har blitt vurdert opp mot gjeldende WCAG-krav for universell utforming. Du kan finne <a href="https://uustatus.no/nb/erklaringer/publisert/52679a09-4af7-486f-87b5-49986439711a"  style="color: #44f55; text-decoration: underline;">tilgjengelighetserklæringen (2023) her</a>.
+Denne nettsiden har blitt vurdert opp mot gjeldende WCAG-krav for universell utforming. Du kan finne <a href="https://uustatus.no/nb/erklaringer/publisert/52679a09-4af7-486f-87b5-49986439711a"  style="color: #44f55; text-decoration: underline;">tilgjengelighetserklæringen her</a>.


### PR DESCRIPTION
Fjernet at vi spesifiserer år så vi slipper å oppdatere hvert år her:
https://trafikkdata.atlas.vegvesen.no/#/om-trafikkdata:~:text=kan%20finne%20tilgjengelighetserkl%C3%A6ringen-,(2023),-her.