### PR TITLE
Style mail link like other links

### DIFF
--- a/docs/contact/Kontakt.md
+++ b/docs/contact/Kontakt.md
@@ -1,2 +1,2 @@
 Vi setter pris på tilbakemeldinger om trafikkdataportalen for å kunne gjøre forbedringer og rette feil.
-Send en e-post til <a href="mailto:trafikkdata@vegvesen.no?subject=Tilbakemelding trafikkdataportalen">trafikkdata@vegvesen.no</a>.
+Send en e-post til <a href="mailto:trafikkdata@vegvesen.no?subject=Tilbakemelding trafikkdataportalen" style="color: #44f55; text-decoration: underline;">trafikkdata@vegvesen.no</a>.


### PR DESCRIPTION
Stylet maillinken på kontaktsiden (https://trafikkdata.atlas.vegvesen.no/#/kontakt) som andre lenker. Ikke superfan av inline styling som det, men siden det er markdown, og det er gjort sånn alle lignende steder, måtte det nesten bli sånn.

Kopierte stylinga fra `docs/about/1-om-trafikkdata.md` så ting skal se likt ut.

